### PR TITLE
Fix icon positioning if no label is set

### DIFF
--- a/src/Icon.Label.js
+++ b/src/Icon.Label.js
@@ -61,6 +61,9 @@ L.Icon.Label = L.Icon.extend({
 
 	_createLabel: function (img) {
 		if (!this.options.labelText) {
+			var pos = this.options.iconSize.divideBy(2);
+			img.style.marginLeft = (-pos.x) + 'px';
+			img.style.marginTop = (-pos.y) + 'px';
 			return img;
 		}
 


### PR DESCRIPTION
If you create a marker using iconlabel and you have no label it skips creating the label element and just returns the img.
In this case the img would not get the correct offset applied and would appear in the wrong place.
